### PR TITLE
Events plugin has a trailing comma that causes IE problems

### DIFF
--- a/src/flot/jquery.flot.events.js
+++ b/src/flot/jquery.flot.events.js
@@ -184,7 +184,7 @@
             
             tooltip.css({
                 top: y - tooltip.height() - 5,
-                left: x,
+                left: x
             });
         };
         


### PR DESCRIPTION
Also, Google Closure Compiler isn't able to minify the file because of that one little comma.
